### PR TITLE
Workaround microsoft cl violation of C standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ node_modules/
 /linux/install-sh
 /linux/config.status
 /linux/config.sub
+/linux/config.h
+/linux/stamp-h1
 /linux/aclocal.m4
 /linux/configure
 /linux/depcomp

--- a/libteol0/teonet_l0_client_crypt.h
+++ b/libteol0/teonet_l0_client_crypt.h
@@ -54,8 +54,8 @@ typedef struct teoLNullCPacket teoLNullCPacket;
 typedef struct KeyExchangePayload_Common {
     //! in ANY key exchange struct first byte must be zero
     uint8_t nul_byte;
-    //! encryption protocol id
-    teoLNullEncryptionProtocol protocolId : 16;
+    //! encryption protocol id, teoLNullEncryptionProtocol enum
+    uint16_t protocolId : 16;
 } KeyExchangePayload_Common;
 #pragma pack(pop)
 


### PR DESCRIPTION
in microsoft compiler enum is int, no matter what
even if all values in small range, even under pragma pack(1), even if it's bitfield of smaller size
Shame on microsoft, bad boy, never loved them