### PR TITLE
Fix/workaround encryption context race

### DIFF
--- a/libteol0/teonet_l0_client.h
+++ b/libteol0/teonet_l0_client.h
@@ -331,16 +331,19 @@ TEOCLI_API ssize_t teoLNullRecvTimeout(teoLNullConnectData *con,
 TEOCLI_API bool teoLNullReadEventLoop(teoLNullConnectData *con, int timeout);
 
 // Low level functions
-TEOCLI_API size_t teoLNullPacketCreateLogin(teoLNullEncryptionContext *ctx, void *buffer, size_t buffer_length,
+TEOCLI_API size_t teoLNullPacketCreateLogin(void *buffer, size_t buffer_length,
                                             const char *host_name);
-TEOCLI_API size_t teoLNullPacketCreateEcho(teoLNullEncryptionContext *ctx, void *msg_buf, size_t buf_len,
+TEOCLI_API size_t teoLNullPacketCreateEcho(void *msg_buf, size_t buf_len,
                                            const char *peer_name,
                                            const char *msg);
-TEOCLI_API size_t teoLNullPacketCreate(teoLNullEncryptionContext *ctx, void *buffer, size_t buffer_length,
+TEOCLI_API size_t teoLNullPacketCreate(void *buffer, size_t buffer_length,
                                        uint8_t command, const char *peer,
                                        const uint8_t *data, size_t data_length);
-TEOCLI_API ssize_t teoLNullPacketSend(teoLNullConnectData *con, teoLNullCPacket *data,
-                                      size_t data_length);
+TEOCLI_API void teoLNullPacketSeal(teoLNullEncryptionContext *ctx,
+                                   bool with_encryption,
+                                   teoLNullCPacket *packet);
+TEOCLI_API ssize_t teoLNullPacketSend(teoLNullConnectData *con, bool with_encryption,
+                                      teoLNullCPacket *data, size_t data_length);
 TEOCLI_API void teoLNullPacketUpdateChecksums(teoLNullCPacket *packet);
 
 TEOCLI_API uint8_t *teoLNullPacketGetPayload(teoLNullCPacket *packet);

--- a/libteol0/teonet_l0_client.h
+++ b/libteol0/teonet_l0_client.h
@@ -339,8 +339,9 @@ TEOCLI_API size_t teoLNullPacketCreateEcho(teoLNullEncryptionContext *ctx, void 
 TEOCLI_API size_t teoLNullPacketCreate(teoLNullEncryptionContext *ctx, void *buffer, size_t buffer_length,
                                        uint8_t command, const char *peer,
                                        const uint8_t *data, size_t data_length);
-TEOCLI_API ssize_t teoLNullPacketSend(teoLNullConnectData *con, const char *data,
+TEOCLI_API ssize_t teoLNullPacketSend(teoLNullConnectData *con, teoLNullCPacket *data,
                                       size_t data_length);
+TEOCLI_API void teoLNullPacketUpdateChecksums(teoLNullCPacket *packet);
 
 TEOCLI_API uint8_t *teoLNullPacketGetPayload(teoLNullCPacket *packet);
 TEOCLI_API teoLNullCPacket *teoLNullPacketGetFromBuffer(uint8_t *data, size_t data_len);

--- a/main_select_trudp.c
+++ b/main_select_trudp.c
@@ -151,7 +151,8 @@ void event_cb(void *tcd, teoLNullEvents event, void *data,
                 char buf[BUFFER_SIZE];
                 
                 // Send peers request
-                size_t pkg_length = teoLNullPacketCreate(NULL, buf, BUFFER_SIZE, /*79*/  CMD_L_PEERS, param->peer_name, NULL, 0);
+                size_t pkg_length = teoLNullPacketCreate(buf, BUFFER_SIZE, /*79*/  CMD_L_PEERS, param->peer_name, NULL, 0);
+
                 ssize_t snd = trudpChannelSendData(tcd, buf, pkg_length);
                 //
                 printf("Send %d bytes packet to L0 server to peer %s, "
@@ -159,7 +160,7 @@ void event_cb(void *tcd, teoLNullEvents event, void *data,
                        (int)snd, param->peer_name, CMD_L_PEERS);
 
                 // Send lients request
-                pkg_length = teoLNullPacketCreate(NULL, buf, BUFFER_SIZE, CMD_L_L0_CLIENTS, param->peer_name, NULL, 0);
+                pkg_length = teoLNullPacketCreate(buf, BUFFER_SIZE, CMD_L_L0_CLIENTS, param->peer_name, NULL, 0);
                 snd = trudpChannelSendData(tcd, buf, pkg_length);
                 //
                 printf("Send %d bytes packet to L0 server to peer %s, "
@@ -637,7 +638,7 @@ static trudpChannelData *trudpLNullLogin(trudpData *td, const char * host_name) 
     char buf[buf_len];
     #endif
 
-    size_t pkg_length = teoLNullPacketCreateLogin(NULL, buf, buf_len, host_name);
+    size_t pkg_length = teoLNullPacketCreateLogin(buf, buf_len, host_name);
     if(!pkg_length) return NULL;
 
     tcd = trudpChannelNew(td, remote_address, remote_port_i, 0);
@@ -776,12 +777,12 @@ int main(int argc, char** argv) {
 
                     char buf[BUFFER_SIZE];
                     // Send ping
-                    size_t pkg_length = teoLNullPacketCreateEcho(NULL, buf, BUFFER_SIZE, param.peer_name, param.msg);
+                    size_t pkg_length = teoLNullPacketCreateEcho(buf, BUFFER_SIZE, param.peer_name, param.msg);
                     trudpChannelSendData(tcd, buf, pkg_length);
                     
 //                    // Send cmd 129
-//                    pkg_length = teoLNullPacketCreate(NULL, buf, BUFFER_SIZE, 129, "teo-wg-users"/*param.peer_name*/, NULL, 0);
-//                    trudpChannelSendData(tcd, buf, pkg_length);
+//                    pkg_length = teoLNullPacketCreate(buf, BUFFER_SIZE, 129, "teo-wg-users"/*param.peer_name*/, NULL, 0);
+//                   trudpChannelSendData(tcd, buf, pkg_length);
 
                     tt_s = tt;
                 }

--- a/main_select_trudp.c
+++ b/main_select_trudp.c
@@ -469,9 +469,8 @@ static void trudpEventCback(void *tcd_pointer, int event, void *data, size_t dat
 
             // Process ECHO command
             if(cp->cmd == CMD_L_ECHO) {
-
                 cp->cmd = CMD_L_ECHO_ANSWER;
-                cp->header_checksum = get_byte_checksum(cp, sizeof(teoLNullCPacket) - sizeof(cp->header_checksum));
+                teoLNullPacketUpdateChecksums(cp);
                 trudpChannelSendData(tcd, cp, ready_count);
             }
             // Send other commands to L0 event loop


### PR DESCRIPTION
Move packet encryption behind synchronizing pipe avoiding race conditions for encryption context in multithreaded environment