### PR TITLE
Fix type confusion in options.

### DIFF
--- a/libteol0/teonet_l0_client_crypt.c
+++ b/libteol0/teonet_l0_client_crypt.c
@@ -3,7 +3,7 @@
 #include "teobase/logging.h"
 #include <assert.h>
 
-extern int teocliOpt_DBG_packetFlow;
+extern bool teocliOpt_DBG_packetFlow;
 
 typedef struct KeyExchangePayload_ECDH_AES_128_V1 {
     //! common.protocolId, must be ENC_PROTO_ECDH_AES_128_V1


### PR DESCRIPTION
Variable teocliOpt_DBG_packetFlow was declared as `bool` but used as `int`. This was randomly turning logs on.