### PR TITLE
Fix/big port numbers

### DIFF
--- a/libteol0/teonet_l0_client.c
+++ b/libteol0/teonet_l0_client.c
@@ -1398,7 +1398,7 @@ _teoLNullConnectionInitiate(teoLNullConnectData *con,
  * @retval teoLNullConnectData::status==-3 - Client-connect() error
  * @retval teoLNullConnectData::status==-4 - Pipe creation error
  */
-teoLNullConnectData *teoLNullConnectE(const char *server, int16_t port,
+teoLNullConnectData *teoLNullConnectE(const char *server, uint16_t port,
                                       teoLNullEventsCb event_cb,
                                       void *user_data,
                                       PROTOCOL connection_flag) {
@@ -1581,7 +1581,7 @@ teoLNullConnectData *teoLNullConnectE(const char *server, int16_t port,
  * @retval teoLNullConnectData::status==-2 - HOST NOT FOUND error
  * @retval teoLNullConnectData::status==-3 - Client-connect() error
  */
-teoLNullConnectData *teoLNullConnect(const char *server, int16_t port,
+teoLNullConnectData *teoLNullConnect(const char *server, uint16_t port,
                                      PROTOCOL connection_flag) {
     return teoLNullConnectE(server, port, NULL, NULL, connection_flag);
 }

--- a/libteol0/teonet_l0_client.h
+++ b/libteol0/teonet_l0_client.h
@@ -317,9 +317,9 @@ teoLNullAcquireCrypto(teoLNullConnectData *con);
 TEOCLI_API void teoLNullUnlockCrypto(teoLNullEncryptionContext *ctx);
 
 TEOCLI_API teoLNullConnectData *
-teoLNullConnect(const char *server, int16_t port, PROTOCOL connection_flag);
+teoLNullConnect(const char *server, uint16_t port, PROTOCOL connection_flag);
 TEOCLI_API teoLNullConnectData *
-teoLNullConnectE(const char *server, int16_t port, teoLNullEventsCb event_cb,
+teoLNullConnectE(const char *server, uint16_t port, teoLNullEventsCb event_cb,
                  void *user_data, PROTOCOL connection_flag);
 TEOCLI_API void teoLNullDisconnect(teoLNullConnectData *con);
 TEOCLI_API void teoLNullShutdown(teoLNullConnectData *con);

--- a/libteol0/teonet_l0_client.h
+++ b/libteol0/teonet_l0_client.h
@@ -143,7 +143,7 @@ typedef struct ksnet_arp_data {
                   ///< 1 - r-host, 2 - TCP Proxy peer
     char addr[ARP_TABLE_IP_SIZE]; ///< Peer IP address
     // \todo test is it possible to change this structure for running peers
-    int16_t port; ///< Peer port
+    uint16_t port; ///< Peer port
 
     double last_activity;      ///< Last time received data from peer
     double last_triptime_send; ///< Last time when triptime request send


### PR DESCRIPTION
Changing type of the port member in ksnet_arp_data structure should also fix connection problems between teonet network peers.